### PR TITLE
added support for SpecFlow 2.0.0

### DIFF
--- a/src/SpecFlow.Dnx/Fixer.cs
+++ b/src/SpecFlow.Dnx/Fixer.cs
@@ -28,7 +28,10 @@ namespace SpecFlow.Dnx
 		public Fixer()
 		{
 			// TODO: Allow for other DNX install locations.
-			SpecFlowExe = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), @".dnx\packages\SpecFlow\1.9.0\tools\specflow.exe");
+			SpecFlowExe = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), @".dnx\packages\SpecFlow\2.0.0\tools\specflow.exe");
+
+            if (!File.Exists(SpecFlowExe))
+                SpecFlowExe = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), @".dnx\packages\SpecFlow\1.9.0\tools\specflow.exe");
 
 			if (!File.Exists(SpecFlowExe))
 				throw new Exception("Can't find SpecFlow: " + SpecFlowExe);
@@ -184,6 +187,10 @@ namespace SpecFlow.Dnx
 			// Set the "ToolsVersion" to VS2013, see: https://github.com/techtalk/SpecFlow/issues/471
 			sb.Append(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+	<PropertyGroup>
+		<RootNamespace>SpecFlow.GeneratedTests</RootNamespace>
+		<AssemblyName>SpecFlow.GeneratedTests</AssemblyName>
+	</PropertyGroup>
 	<ItemGroup>
 		<None Include=""app.config"">
 			<SubType>Designer</SubType>

--- a/src/SpecFlow.Dnx/project.json
+++ b/src/SpecFlow.Dnx/project.json
@@ -7,7 +7,6 @@
 	"licenseUrl": "https://github.com/stajs/SpecFlow.Dnx/blob/master/LICENSE",
 
 	"dependencies": {
-		"SpecFlow": "1.9.0"
 	},
 
 	"commands": {
@@ -15,7 +14,7 @@
 	},
 
 	"frameworks": {
-		"net40": {
+		"net451": {
 			"frameworkAssemblies": {
 				"System.Xml": "4.0.0.0",
 				"System.Xml.Linq": "4.0.0.0"


### PR DESCRIPTION
I'm using ASPNET Core and SpecFlow on a project and wanted to upgrade to SpecFlow 2 for the better parallel test running support.

I noticed that the reference to specflow.exe was hard-coded to 1.9.0. When I pulled down the code and updated the reference I also noticed that the feature.cs files wouldn't generate unless the fake csproj had a RootNamepace and AssemblyName.

I'm currently using the modified code locally but thought it would nice if SpecFlow 2 support was added to the NuGet package for other "bleeding edge" teams. I've tried to make sure it's backwards compatible with Specflow 1.9.0.

Cheers,
Luke
