### PR TITLE
Fix project.json framework targets

### DIFF
--- a/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests/project.json
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests/project.json
@@ -11,11 +11,12 @@
 		"Sample.Website": "1.0.0-*",
 		"SpecFlow": "2.1.0",
 		"xunit": "2.2.0-beta2-build3300",
-		"dotnet-test-xunit": "2.2.0-*"
+    "dotnet-test-xunit": "2.2.0-*",
+    "SpecFlow.NetCore": "1.0.0-rc3"
 	},
 
 	"tools": {
-		"SpecFlow.NetCore": "1.0.0-rc2"
+		"SpecFlow.NetCore": "1.0.0-rc3"
 	},
 
 	"testRunner": "xunit",

--- a/src/SpecFlow.NetCore/project.json
+++ b/src/SpecFlow.NetCore/project.json
@@ -1,28 +1,32 @@
 ﻿{
-	"version": "1.0.0-rc2",
-	"description": "Generate tests from SpecFlow feature files inside ASP.NET Core projects (.xproj's).",
-	"authors": [ "stajs" ],
+  "version": "1.0.0-rc3",
+  "description": "Generate tests from SpecFlow feature files inside ASP.NET Core projects (.xproj's).",
+  "authors": [ "stajs" ],
 
-	"packOptions": {
-		"tags": [ "SpecFlow", ".NET Core", "ASP.NET Core", "ASP.NET 5", "Visual Studio 2015", "xproj" ],
-		"projectUrl": "https://github.com/stajs/SpecFlow.NetCore",
-		"licenseUrl": "https://github.com/stajs/SpecFlow.NetCore/blob/master/LICENSE"
-	},
+  "packOptions": {
+    "tags": [ "SpecFlow", ".NET Core", "ASP.NET Core", "ASP.NET 5", "Visual Studio 2015", "xproj" ],
+    "projectUrl": "https://github.com/stajs/SpecFlow.NetCore",
+    "licenseUrl": "https://github.com/stajs/SpecFlow.NetCore/blob/master/LICENSE"
+  },
 
-	"buildOptions": {
-		"emitEntryPoint": true,
-		"outputName": "dotnet-SpecFlow.NetCore"
-	},
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "outputName": "dotnet-SpecFlow.NetCore"
+  },
 
-	"dependencies": {
-		"Microsoft.NETCore.App": {
-			"type": "platform",
-			"version": "1.0.0"
-		},
-		"System.Xml.XPath.XDocument": "4.0.1"
-	},
+  "dependencies": {
+    "System.Xml.XPath.XDocument": "4.0.1"
+  },
 
-	"frameworks": {
-		"netcoreapp1.0": {}
-	}
+  "frameworks": {
+    "netcoreapp1.0": {  
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    },
+    "net46": {}
+  }
 }


### PR DESCRIPTION
Fixes #24 

See Sample.Website.Tests project.json for how you can now reference the project in dependencies. I'm not very good with project.json:s but this works fine on my machine. 

I downgraded our target framework to "net46" as it seems to make  no difference other than including net46 projects as well as net461.

Stajs, is there any way to provide a for-this-project whitespace configuration or settings file? I seem to have different settings than you do and I just don't like the diffs. If not, can you share your vs settings with me so I don't accidentally auto-format files? :)
