### PR TITLE
Scenario Outline tests are correctly categorized

### DIFF
--- a/src/SpecFlow.NetCore/AppConfig.cs
+++ b/src/SpecFlow.NetCore/AppConfig.cs
@@ -52,6 +52,14 @@ namespace SpecFlow.NetCore
 				return config;
 
 			Content = string.Format(Content, testFramework);
+
+			// fixes SpecFlow Scenario Outline scenarios appearing under the project they belong to.
+			// see https://github.com/stajs/SpecFlow.NetCore/issues/34 and https://github.com/techtalk/SpecFlow/issues/275
+			if (testFramework.ToLower() == "mstest")
+			{
+				Content = Content.Replace("</specFlow>", "  <generator allowDebugGeneratedFiles=\"true\" />\r\n  </specFlow>");
+			}
+
 			WriteLine("Generating app.config");
 			WriteLine(Content);
 			WriteLine("Saving: " + config.Path);


### PR DESCRIPTION
They will be categorized under the project the feature file belongs to
instead of being categorized under External.

See https://github.com/techtalk/SpecFlow/issues/275.

Fixes #34
