### PR TITLE
attempts to resolve latest specflow version to assist with #40

### DIFF
--- a/src/SpecFlow.NetCore/Fixer.cs
+++ b/src/SpecFlow.NetCore/Fixer.cs
@@ -68,7 +68,7 @@ namespace SpecFlow.NetCore
 			var specflowVersions = Directory.GetDirectories(specflowVersionsDirectory);
 			var latestSpecflowVersion = specflowVersions.Max();
 			if (specflowVersions.Length > 1)
-				WriteLine("Found multiple versions of SpecFlow in the NUGET_PACKAGES directory, using '{0}'.", latestSpecflowVersion);
+				WriteLine("Found multiple versions of SpecFlow in the '{0}' directory, using '{1}'.", environmentVariable, latestSpecflowVersion);
 			return Path.Combine(specflowVersionsDirectory, latestSpecflowVersion, RelativePathToSpecFlowApplication);
 		}
 

--- a/src/SpecFlow.NetCore/Properties/AssemblyInfo.cs
+++ b/src/SpecFlow.NetCore/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/SpecFlow.NetCore/project.json
+++ b/src/SpecFlow.NetCore/project.json
@@ -1,5 +1,5 @@
 ﻿{
-	"version": "1.0.0-rc7",
+	"version": "1.0.0-rc8",
 	"description": "Generate tests from SpecFlow feature files inside ASP.NET Core projects (.xproj's).",
 	"authors": [ "stajs" ],
 


### PR DESCRIPTION
Completely untested for now, but something like this would possibly be better than hardcoding a version? I appreciate there is a mechanism to override the hardcoded value already, but this seems more convenient for little work?