### PR TITLE
Made change required for working with .NET Core 2.0

### DIFF
--- a/samples/VS2015/SpecFlow 2.1.0/net461/NuGet.config
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/NuGet.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="specflownetcore" value="https://www.myget.org/F/specflownetcore/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.MsTest/Sample.Website.Tests.MSTest.csproj
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.MsTest/Sample.Website.Tests.MSTest.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc7" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc9-00004" />
   </ItemGroup>
 
 </Project>

--- a/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.NUnit/Sample.Website.Tests.NUnit.csproj
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.NUnit/Sample.Website.Tests.NUnit.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc7" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc9-00004" />
   </ItemGroup>
 
 </Project>

--- a/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.XUnit/Sample.Website.Tests.XUnit.csproj
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.Tests.XUnit/Sample.Website.Tests.XUnit.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc7" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.0.0-rc9-00004" />
   </ItemGroup>
 
 </Project>

--- a/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.sln
+++ b/samples/VS2015/SpecFlow 2.1.0/net461/Sample.Website.sln
@@ -1,9 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{004FCD9D-539C-4CCA-9780-EC56517946C5}"
+	ProjectSection(SolutionItems) = preProject
+		NuGet.config = NuGet.config
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Website", "Sample.Website\Sample.Website.csproj", "{D0D56730-C846-442A-ACE7-1059240B4109}"
 EndProject
@@ -38,5 +41,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {39FFFA0E-ECA7-49EC-B5D3-4980159CA37B}
 	EndGlobalSection
 EndGlobal

--- a/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
+++ b/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Generate tests from SpecFlow feature files inside ASP.NET Core projects (.xproj's).</Description>
-    <VersionPrefix>1.0.0-rc8</VersionPrefix>
+    <VersionPrefix>1.0.0-rc9-00004</VersionPrefix>
     <Authors>stajs</Authors>
     <TargetFrameworks>netcoreapp1.0;net46;net461</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>


### PR DESCRIPTION
Actually no changes was required and most of changes is just to illustrate this.

For anybody who interested to work with this package right now could create NuGet and publish on their own MyGet feed, or use `https://www.myget.org/F/specflownetcore/api/v3/index.json` until @stajs publish to his package.

See #48 for discussion