### PR TITLE
Support for relative paths

### DIFF
--- a/src/SpecFlow.NetCore/Fixer.cs
+++ b/src/SpecFlow.NetCore/Fixer.cs
@@ -30,11 +30,15 @@ namespace SpecFlow.NetCore
 				if (File.Exists(path))
 					return path;
 
-				throw new Exception("Path to SpecFlow was supplied as an argument, but doesn't exist: " + path);
+				if (Path.IsPathRooted(path))
+				{
+					throw new Exception("Path to SpecFlow was supplied as an argument, but doesn't exist: " + path);
+				}
 			}
 
-			const string relativePathToSpecFlow = @"SpecFlow\2.1.0\tools\specflow.exe";
-
+			var relativePathToSpecFlow = string.IsNullOrWhiteSpace(path)
+				? @"SpecFlow\2.1.0\tools\specflow.exe"
+				: path;
 			var nugetPackagesPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
 
 			if (!string.IsNullOrWhiteSpace(nugetPackagesPath))

--- a/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
+++ b/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Generate tests from SpecFlow feature files inside ASP.NET Core projects (.xproj's).</Description>
-    <VersionPrefix>1.0.0-rc9-00004</VersionPrefix>
+    <VersionPrefix>1.0.0-rc9-00005</VersionPrefix>
     <Authors>stajs</Authors>
     <TargetFrameworks>netcoreapp1.0;net46;net461</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>


### PR DESCRIPTION
This PR attempt to address #40 by providing ability specify relative paths to --specflow-path

For example
```
  <Target Name="PrecompileSpecflow" BeforeTargets="BeforeBuild">
    <Exec Command="dotnet SpecFlow.NetCore --specflow-path SpecFlow\2.2.0\tools\specflow.exe" />
  </Target>
```