### PR TITLE
Fixed the regex for removing MSTest descriptions

### DIFF
--- a/src/SpecFlow.NetCore/Fixer.cs
+++ b/src/SpecFlow.NetCore/Fixer.cs
@@ -117,7 +117,7 @@ namespace SpecFlow.NetCore
 
 		private static string FixMsTest(string content)
 		{
-			content = Regex.Replace(content, ".*Microsoft.VisualStudio.TestTools.UnitTesting.Description.*", "");
+			content = Regex.Replace(content, @"\[Microsoft\.VisualStudio\.TestTools\.UnitTesting\.Description.*?\)]", "", RegexOptions.Singleline);
 			return content;
 		}
 


### PR DESCRIPTION
Use the /s option to check on multiple lines for the attribute to close. # #54 