### PR TITLE
Make tools version configurable

### DIFF
--- a/src/SpecFlow.NetCore/Args.cs
+++ b/src/SpecFlow.NetCore/Args.cs
@@ -10,10 +10,12 @@ namespace Specflow.NetCore
 		public const string SpecFlowPathArgName = "--specflow-path";
 		public const string WorkingDirectoryArgName = "--working-directory";
 		public const string TestFrameworkArgName = "--test-framework";
+		public const string ToolsVersionArgName = "--tools-version";
 
 		public string SpecFlowPath { get; }
 		public DirectoryInfo WorkingDirectory { get; }
 		public string TestFramework { get; }
+		public string ToolsVersion { get; }
 
 		public Args(string[] args)
 		{
@@ -53,6 +55,10 @@ namespace Specflow.NetCore
 
 					case TestFrameworkArgName:
 						TestFramework = value;
+						break;
+
+					case ToolsVersionArgName:
+						ToolsVersion = value;
 						break;
 
 					default:

--- a/src/SpecFlow.NetCore/Fixer.cs
+++ b/src/SpecFlow.NetCore/Fixer.cs
@@ -16,13 +16,13 @@ namespace SpecFlow.NetCore
 		private FileInfo[] _featureFiles;
 		private readonly string _toolsVersion;
 
-		public Fixer(string specFlowPath = null, string testFramework = null, string toolsVersion = null)
+		public Fixer(string specFlowPath = null, string testFramework = null, string toolsVersion = "14.0")
 		{
 			_specFlowExe = FindSpecFlow(specFlowPath);
 			WriteLine("Found: " + _specFlowExe);
 
 			_testFramework = testFramework;
-			_toolsVersion = toolsVersion ?? "14.0";
+			_toolsVersion = toolsVersion;
 		}
 
 		private string FindSpecFlow(string path)

--- a/src/SpecFlow.NetCore/Fixer.cs
+++ b/src/SpecFlow.NetCore/Fixer.cs
@@ -14,13 +14,15 @@ namespace SpecFlow.NetCore
 		private readonly string _specFlowExe;
 		private string _testFramework;
 		private FileInfo[] _featureFiles;
+		private readonly string _toolsVersion;
 
-		public Fixer(string specFlowPath = null, string testFramework = null)
+		public Fixer(string specFlowPath = null, string testFramework = null, string toolsVersion = null)
 		{
 			_specFlowExe = FindSpecFlow(specFlowPath);
 			WriteLine("Found: " + _specFlowExe);
 
 			_testFramework = testFramework;
+			_toolsVersion = toolsVersion ?? "14.0";
 		}
 
 		private string FindSpecFlow(string path)
@@ -184,8 +186,8 @@ namespace SpecFlow.NetCore
 			var sb = new StringBuilder();
 
 			// Set the "ToolsVersion" to VS2013, see: https://github.com/techtalk/SpecFlow/issues/471
-			sb.Append(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+			sb.Append($@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""{_toolsVersion}"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
 	<PropertyGroup>
 		<RootNamespace>SpecFlow.GeneratedTests</RootNamespace>
 		<AssemblyName>SpecFlow.GeneratedTests</AssemblyName>

--- a/src/SpecFlow.NetCore/Program.cs
+++ b/src/SpecFlow.NetCore/Program.cs
@@ -10,7 +10,7 @@ namespace SpecFlow.NetCore
 			try
 			{
 				var a = new Args(args);
-				var fixer = new Fixer(a.SpecFlowPath, a.TestFramework);
+				var fixer = new Fixer(a.SpecFlowPath, a.TestFramework, a.ToolsVersion);
 				fixer.Fix(a.WorkingDirectory);
 
 				PrintUsingColor("SpecFlow fixed.", ConsoleColor.Green);


### PR DESCRIPTION
Resolved #56 with a new optional command line argument --tools-version.

--tools-version defaults to 14.0. When running SpecFlow.NetCore on an machine with only Visual Studio 2017 installed then set --tools-version to 4.0.