### PR TITLE
Add .net core 2.1 target

### DIFF
--- a/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.MsTest/Sample.Website.Tests.MSTest.csproj
+++ b/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.MsTest/Sample.Website.Tests.MSTest.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.3" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.NUnit/Sample.Website.Tests.NUnit.csproj
+++ b/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.NUnit/Sample.Website.Tests.NUnit.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.3" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.XUnit/Sample.Website.Tests.XUnit.csproj
+++ b/samples/VS2017/SpecFlow 2.1.0/net461/Sample.Website.Tests.XUnit/Sample.Website.Tests.XUnit.csproj
@@ -36,7 +36,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.3" />
+    <DotNetCliToolReference Include="SpecFlow.NetCore" Version="1.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
+++ b/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Generate tests from SpecFlow feature files inside .NET Core projects.</Description>
     <Authors>stajs</Authors>
-    <TargetFrameworks>netcoreapp2.0;net46;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net46;net461</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <AssemblyName>dotnet-SpecFlow.NetCore</AssemblyName>
@@ -20,7 +20,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
+++ b/src/SpecFlow.NetCore/SpecFlow.NetCore.csproj
@@ -21,7 +21,6 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <PackageReleaseNotes></PackageReleaseNotes>
     <Version>1.3.4</Version>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We ran into an issue with using this package in a project targeting .net core 2.1. We fixed it by adding 2.1 to the TargetFrameworks